### PR TITLE
Feat/#80/뉴스 히스토리 확인 및 UI 수정

### DIFF
--- a/src/app/user/historyPage/page.tsx
+++ b/src/app/user/historyPage/page.tsx
@@ -118,7 +118,7 @@ export default function HistoryPage() {
                   }
                 }}
               />
-              <Dropdown
+              {/* <Dropdown
                 type="result"
                 onChange={(value) => {
                   setResultFilter(
@@ -129,7 +129,7 @@ export default function HistoryPage() {
                       : "all"
                   );
                 }}
-              />
+              /> */}
             </div>
           )}
         </div>

--- a/src/app/user/parent/[studentId]/page.tsx
+++ b/src/app/user/parent/[studentId]/page.tsx
@@ -19,6 +19,7 @@ import Slider from "../../components/Slider";
 import HistoryBtn from "../../components/HistoryBtn";
 import QuizBtn from "../components/QuizBtn";
 import { getStudentInfoById, StdInfoResponse } from "@/apis/studentInfo";
+import AssignLoading from "@/components/shared/AssignLoading";
 
 export default function ParentPage() {
   const { studentId } = useParams();
@@ -97,6 +98,10 @@ export default function ParentPage() {
       .catch((err) => console.error("학생 정보 API 실패:", err))
       .finally(() => setLoadingUser(false));
   }, [id]);
+
+  if (loadingUser) {
+    return <AssignLoading />;
+  }
 
   return (
     <div className="relative w-full px-13 py-7">

--- a/src/app/user/parent/components/StudentCard.tsx
+++ b/src/app/user/parent/components/StudentCard.tsx
@@ -22,7 +22,7 @@ export default function StudentCard({
 }: StudentCardProps) {
   return (
     <div
-      className="relative flex w-64 h-28 rounded-[10px] p-5 border cursor-pointer"
+      className="relative flex w-64 h-28 rounded-[10px] p-5 border cursor-pointer hover:bg-gray-100"
       style={{
         borderColor: COLORS.sub.gray3,
         boxShadow: SHADOW.interactive,
@@ -69,7 +69,7 @@ export default function StudentCard({
             onDelete();
           }}
           className="absolute top-2 right-3 flex justify-center items-center w-3 h-3 rounded-full p-2.5"
-          style={{ color: COLORS.sub.white, backgroundColor: COLORS.sub.gray2 }}
+          style={{ color: COLORS.sub.white, backgroundColor: COLORS.sub.gray3 }}
         >
           X
         </button>

--- a/src/app/user/student/page.tsx
+++ b/src/app/user/student/page.tsx
@@ -99,7 +99,7 @@ export default function StudentMyPage() {
           alt="home"
           width={40}
           height={40}
-          onClick={() => router.push("/")}
+          onClick={() => router.push("/student")}
           className="cursor-pointer"
         />
         <div className="flex flex-col -space-y-2">

--- a/src/app/user/studentProgress/components/ProgressItem.tsx
+++ b/src/app/user/studentProgress/components/ProgressItem.tsx
@@ -20,7 +20,7 @@ export default function ProgressItem({ days }: ProgressItemProps) {
             fontWeight: FONT_WEIGHT.subtitle2,
           }}
         >
-          <div>{day}</div>
+          <div>{day.split("T")[0]}</div>
           <div className="flex gap-6">
             {Object.entries(tasks).map(([label, status]) => (
               <StatusBtn

--- a/src/app/user/studentProgress/page.tsx
+++ b/src/app/user/studentProgress/page.tsx
@@ -36,7 +36,7 @@ export default function StudentMyPage() {
         onClick={() => router.push("/user/student")}
         className="cursor-pointer"
       />
-      <div className="flex flex-col items-stretch justify-between w-[900px] pt-10 px-12">
+      <div className="flex flex-col justify-between w-[900px] pt-10 pl-35">
         <div
           className="flex justify-between"
           style={{
@@ -61,7 +61,7 @@ export default function StudentMyPage() {
         {/*진도 현황*/}
         <div className="flex items-center pt-13">
           <div
-            className="flex pl-19 gap-80"
+            className="flex pl-19 gap-70"
             style={{
               fontSize: FONT_SIZE.subtitle1,
               fontWeight: FONT_WEIGHT.subtitle1,

--- a/src/components/shared/MyInfo.tsx
+++ b/src/components/shared/MyInfo.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme/tokens";
 import { getStudentInfo } from "@/apis/studentInfo";
+import Image from "next/image";
 
 export interface StudentInfo {
   std_name: string;
@@ -57,10 +58,13 @@ export default function MyInfo() {
       >
         {student.std_name} 학생
       </div>
-      <img
+      <Image
         className="w-12 h-12 rounded-full"
-        src={student.std_img}
+        src={student.std_img || "/images/logo.svg"}
+        width={12}
+        height={12}
         onClick={() => router.push(`/user/student`)}
+        alt="profile"
       />
     </div>
   );

--- a/src/components/shared/MyInfo.tsx
+++ b/src/components/shared/MyInfo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme/tokens";
 import { getStudentInfo } from "@/apis/studentInfo";
 
@@ -16,6 +17,8 @@ export interface StudentInfo {
 export default function MyInfo() {
   const [student, setStudent] = useState<StudentInfo | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const router = useRouter();
 
   useEffect(() => {
     const fetchStudentInfo = async () => {
@@ -54,7 +57,11 @@ export default function MyInfo() {
       >
         {student.std_name} 학생
       </div>
-      <img className="w-12 h-12 rounded-full" src={student.std_img} />
+      <img
+        className="w-12 h-12 rounded-full"
+        src={student.std_img}
+        onClick={() => router.push(`/user/student`)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Related Issue

close #80

## ✨ Work Description

1. /student에 뜨는 학생 기본 이미지 로고로 수정 
2. 로고 누르면 /user/student로 이동 
3. 뉴스 히스토리 / 진도 현황 문제없이 작동함
4. 정답/오답 드롭다운 숨김 처리
