### PR TITLE
Feat/48/MonWord DB 연결 API 연동

### DIFF
--- a/src/apis/monWord.ts
+++ b/src/apis/monWord.ts
@@ -29,7 +29,7 @@ export const monWordApi = {
         {},
         { headers }
       );
-      console.log("monWord 배정 post 결과", response);
+      // console.log("monWord 배정 post 결과", response);
     } catch (error) {
       console.error("monWord 배정 실패:", error);
     }
@@ -39,9 +39,7 @@ export const monWordApi = {
   getMonWord: async () => {
     try {
       const headers = getAuthHeader();
-      const response = await axios.get(`${baseURL}/monWord`, {
-        headers,
-      });
+      const response = await axios.get(`${baseURL}/monWord`, { headers });
       // console.log("monWord 조회 결과:", response.data);
       return response.data.result;
     } catch (error) {
@@ -71,9 +69,11 @@ export const monWordApi = {
   postMonWordDone: async () => {
     try {
       const headers = getAuthHeader();
-      const response = await axios.post(`${baseURL}/monWord/done`, {
-        headers,
-      });
+      const response = await axios.post(
+        `${baseURL}/monWord/done`,
+        {},
+        { headers }
+      );
       return response.data.result;
     } catch (error) {
       console.error("momWord 학습 완료 post 실패:", error);

--- a/src/apis/monWord.ts
+++ b/src/apis/monWord.ts
@@ -20,6 +20,21 @@ const getAuthHeader = () => {
 };
 
 export const monWordApi = {
+  // monWord 배정
+  postMonWordAssign: async () => {
+    try {
+      const headers = getAuthHeader();
+      const response = await axios.post(
+        `${baseURL}/monWord/assign`,
+        {},
+        { headers }
+      );
+      console.log("monWord 배정 post 결과", response);
+    } catch (error) {
+      console.error("monWord 배정 실패:", error);
+    }
+  },
+
   // monWord 조회
   getMonWord: async () => {
     try {

--- a/src/app/(main)/MonWord/components/WordItem.tsx
+++ b/src/app/(main)/MonWord/components/WordItem.tsx
@@ -4,14 +4,28 @@ import NavyBox from "@/components/ui/NavyBox";
 import CommonBtn from "@/components/shared/CommonBtn";
 import { COLORS, FONT_SIZE, FONT_WEIGHT } from "@/styles/theme/tokens";
 import { Word } from "@/types/monWord";
+import { useState } from "react";
+import { monWordApi } from "@/apis/monWord";
 
-export default function WordItem({
-  id,
-  word,
-  explain,
-  use,
-  understandFunc,
-}: Word) {
+export default function WordItem({ id, word, explain, use }: Word) {
+  const [understood, setUnderstood] = useState<boolean>(false);
+
+  // mon단어 item 이해했어요 post
+  const postTodayMonWordItemUnderstand = async (wordId: number) => {
+    try {
+      const data = await monWordApi.postWordItemUnderstand(wordId);
+      console.log(data);
+      setUnderstood(true);
+    } catch (error: any) {
+      if (error.response) {
+        alert(error.response.data.message);
+      } else {
+        alert("알 수 없는 오류가 발생했습니다.");
+      }
+      console.error("오늘의 monWord 학습 완료 post 실패", error);
+    }
+  };
+
   return (
     <div className="w-[680px] px-10 pt-10 pb-7 bg-white rounded-[30px] flex flex-col gap-5">
       {/* 단어 및 설명 */}
@@ -36,7 +50,12 @@ export default function WordItem({
 
       {/* 버튼 */}
       <div className="flex justify-end">
-        <CommonBtn type="understand" onClick={understandFunc} />
+        <CommonBtn
+          type="understand"
+          onClick={() => postTodayMonWordItemUnderstand(id)}
+        >
+          {understood ? "⭐️ 이해 완료" : "💪🏻 이해했어요"}
+        </CommonBtn>
       </div>
     </div>
   );

--- a/src/app/(main)/MonWord/components/WordList.tsx
+++ b/src/app/(main)/MonWord/components/WordList.tsx
@@ -37,7 +37,7 @@ export default function WordList() {
       const data = await monWordApi.postMonWordDone();
       // console.log(data);
       alert("오늘의 MonWord를 완료했어요!");
-      router.push("/");
+      router.push("/student");
     } catch (error: any) {
       if (error.response) {
         alert(error.response.data.message);
@@ -50,26 +50,6 @@ export default function WordList() {
     }
   };
 
-  // mon단어 item 이해했어요 post
-  const postTodayMonWordItemUnderstand = async (wordId: number) => {
-    try {
-      setIsLoading(true);
-      const data = await monWordApi.postWordItemUnderstand(wordId);
-      console.log(data);
-    } catch (error: any) {
-      if (error.response) {
-        alert(error.response.data.message);
-      } else {
-        alert("알 수 없는 오류가 발생했습니다.");
-      }
-      console.error("오늘의 monWord 학습 완료 post 실패", error);
-    }
-  };
-
-  const handleFinishClick = () => {
-    postTodayMonWordDone();
-  };
-
   return (
     <>
       <div className="px-5 py-7 flex flex-col justify-center items-center gap-5">
@@ -80,14 +60,13 @@ export default function WordList() {
             word={item.word}
             explain={item.explain}
             use={item.use}
-            understandFunc={() => postTodayMonWordItemUnderstand(item.id)}
           />
         ))}
         <div className="">
           <CommonBtn
             type="finish"
             subText="오늘의 MON단어를 다 이해했어요!"
-            onClick={handleFinishClick}
+            onClick={postTodayMonWordDone}
           />
         </div>
       </div>

--- a/src/app/(main)/student/components/MonWord.tsx
+++ b/src/app/(main)/student/components/MonWord.tsx
@@ -6,6 +6,8 @@ import Image from "next/image";
 import WordBox from "@components/ui/WordBox";
 import { useRouter } from "next/navigation";
 import { stdMainApi } from "@/apis/stdMain";
+import { monWordApi } from "@/apis/monWord";
+import AssignLoading from "@/components/shared/AssignLoading";
 
 export default function MonWord() {
   const [monWords, setMonWords] = useState<string[]>([]);
@@ -13,20 +15,43 @@ export default function MonWord() {
   const router = useRouter();
 
   useEffect(() => {
-    const fetchTodayMonQuizMark = async () => {
+    // monWord 배정 후 monWord 조회
+    const monWordAssign = async () => {
       try {
         setIsLoading(true);
-        const data = await stdMainApi.getStdMonWord();
-        setMonWords(data);
-      } catch (error) {
-        console.error("오늘 monQuiz 채점 조회 실패: ", error);
+        await monWordApi.postMonWordAssign();
+        fetchStdMonWord();
+      } catch (error: any) {
+        console.error("오늘 monWord 배정 실패: ", error);
+        const msg = error.response?.message || "서버와 연결할 수 없습니다.";
+        alert(msg);
       } finally {
         setIsLoading(false);
       }
     };
 
-    fetchTodayMonQuizMark();
+    const fetchStdMonWord = async () => {
+      try {
+        setIsLoading(true);
+        const data = await stdMainApi.getStdMonWord();
+        // console.log("학생 메인 monWord:", data);
+
+        const words = data.map(
+          (item: { id: number; word: string }) => item.word
+        );
+
+        setMonWords(words);
+      } catch (error) {
+        console.error("오늘 monWord 조회 실패: ", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    monWordAssign();
   }, []);
+
+  if (isLoading) return <AssignLoading />;
 
   return (
     <>

--- a/src/components/shared/CommonBtn.tsx
+++ b/src/components/shared/CommonBtn.tsx
@@ -13,6 +13,7 @@ interface CommonBtnProps {
     | "monday_complete"; // 패딩
   subText?: string;
   seriesName?: string;
+  children?: React.ReactNode;
   onClick: () => void;
 }
 
@@ -20,6 +21,7 @@ export default function CommonBtn({
   type,
   subText,
   seriesName,
+  children,
   onClick,
 }: CommonBtnProps) {
   return (
@@ -37,7 +39,7 @@ export default function CommonBtn({
               fontWeight: FONT_WEIGHT.caption1,
             }}
           >
-            💪🏻 이해했어요
+            {children}
           </div>
         </div>
       )}

--- a/src/types/monWord.ts
+++ b/src/types/monWord.ts
@@ -4,5 +4,4 @@ export interface Word {
   word: string;
   explain: React.ReactNode;
   use: string;
-  understandFunc: () => void;
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
#46 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- monWord 배정 post API 연동
- monWord 조회/이해했어요/학습완료 API 수정
- 학생 메인 monWord API 연동
- monWord 페이지(`wordItem.js`, `wordList.js`) 로직 변경

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
> monWord 페이지에서 이해했어요 버튼은 하나 아이템 당 1회만 가능 ! 여러번 할 시 오류 발생


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 학생 메인 페이지 | monWord 페이지 |
| --- | --- |
| <img width="1110" height="697" alt="스크린샷 2025-09-21 23 14 56" src="https://github.com/user-attachments/assets/588e31d0-bd88-490e-8b0a-349cf3c51378" /> | <img width="1125" height="697" alt="스크린샷 2025-09-21 23 15 34" src="https://github.com/user-attachments/assets/55fbb4cf-71cd-4190-aca9-7356744e7e15" /> |
