### PR TITLE
Feat/#93/히스토리 API 수정

### DIFF
--- a/constants/categoryColor.ts
+++ b/constants/categoryColor.ts
@@ -1,12 +1,12 @@
 import { COLORS } from "@/styles/theme/tokens";
 
 export const Category_Color = {
-  MONEY: COLORS.category.money,
-  BIGPICTURE: COLORS.category.bigPicture,
-  DAILYLIFE: COLORS.category.dailyLife,
-  GLOBAL: COLORS.category.global,
-  INDUSTRIES: COLORS.category.industries,
-  ISSUES: COLORS.category.issues,
-  TECH: COLORS.category.tech,
-  RULES: COLORS.category.rules,
+  cg00: COLORS.category.money,
+  cg01: COLORS.category.bigPicture,
+  cg02: COLORS.category.dailyLife,
+  cg03: COLORS.category.global,
+  cg04: COLORS.category.industries,
+  cg05: COLORS.category.issues,
+  cg06: COLORS.category.tech,
+  cg07: COLORS.category.rules,
 };

--- a/constants/categoryLabel.tsx
+++ b/constants/categoryLabel.tsx
@@ -1,10 +1,10 @@
 export const Category_Label = {
-  MONEY: { label: "금융/시장", value: "MONEY" },
-  BIGPICTURE: { label: "거시경제", value: "BIGPICTURE" },
-  DAILYLIFE: { label: "생활경제", value: "DAILYLIFE" },
-  GLOBAL: { label: "글로벌경제", value: "GLOBAL" },
-  INDUSTRIES: { label: "산업/기업", value: "INDUSTRIES" },
-  ISSUES: { label: "특집/이슈", value: "ISSUES" },
-  TECH: { label: "테크/신사업", value: "TECH" },
-  RULES: { label: "정책/규제", value: "RULES" },
+  cg00: { label: "금융/시장", value: "cg00" },
+  cg01: { label: "거시경제", value: "cg01" },
+  cg02: { label: "생활경제", value: "cg02" },
+  cg03: { label: "글로벌경제", value: "cg03" },
+  cg04: { label: "산업/기업", value: "cg04" },
+  cg05: { label: "특집/이슈", value: "cg05" },
+  cg06: { label: "테크/신사업", value: "cg06" },
+  cg07: { label: "정책/규제", value: "cg07" },
 };

--- a/src/apis/newsHistory.ts
+++ b/src/apis/newsHistory.ts
@@ -2,7 +2,7 @@ import { Category } from "@/types/category";
 import { API } from "./config";
 
 export interface News {
-  newsId: number;
+  mnId: number;
   category: Category;
   title: string;
   imgUrl: string;

--- a/src/apis/newsHistory.ts
+++ b/src/apis/newsHistory.ts
@@ -22,3 +22,13 @@ export async function getNewsHistory(
   console.log("API response:", res.data);
   return res.data;
 }
+
+export async function getParentNewsHistory(
+  week: "이번주" | "저번주"
+): Promise<NewsHistoryResponse> {
+  const res = await API.get<NewsHistoryResponse>(
+    `/users/parent/history/news?week=${week}`
+  );
+  console.log("API response:", res.data);
+  return res.data;
+}

--- a/src/apis/parentInfo.ts
+++ b/src/apis/parentInfo.ts
@@ -15,3 +15,27 @@ export async function getParentInfo(): Promise<PrtInfoResponse> {
   console.log("API response:", res.data.result);
   return res.data.result;
 }
+
+// 부모에게 자녀 추가
+interface AddStudentRequest {
+  studentId: string;
+}
+
+interface AddStudentResponse {
+  message: string;
+  student: {
+    id: string;
+    name: string;
+    school: string;
+    grade: string;
+  };
+}
+
+export async function addStudent(
+  studentId: string
+): Promise<AddStudentResponse> {
+  const reqBody: AddStudentRequest = { studentId }; // 인터페이스 사용
+  const res = await API.post<AddStudentResponse>("/add-student", reqBody);
+  console.log("자녀 추가 API response:", res.data);
+  return res.data;
+}

--- a/src/apis/parentInfo.ts
+++ b/src/apis/parentInfo.ts
@@ -4,6 +4,7 @@ export interface PrtInfoResponse {
   prt_name: string;
   prt_email: string;
   prt_phone: string;
+  studentIds: string[];
 }
 
 interface PrtInfoAPIResponse {

--- a/src/apis/progress.ts
+++ b/src/apis/progress.ts
@@ -14,7 +14,7 @@ export interface ProgressDay {
 
 export interface ProgressResponse {
   weekCompletionRate: number;
-  strikeDay: number;
+  strikeDay?: number;
   days: ProgressDay[];
 }
 

--- a/src/apis/progress.ts
+++ b/src/apis/progress.ts
@@ -3,7 +3,6 @@ import { API } from "./config";
 export interface Task {
   word: string;
   news: string;
-  series: string;
   quiz: string;
 }
 

--- a/src/apis/progress.ts
+++ b/src/apis/progress.ts
@@ -26,12 +26,11 @@ export async function getProgress(
   return res.data;
 }
 
-export async function getStudentProgress(
-  studentId: string,
+export async function getParentProgress(
   week: "이번주" | "저번주"
 ): Promise<ProgressResponse> {
   const res = await API.get<ProgressResponse>(
-    `/users/${studentId}/progress?week=${week}`
+    `/users/parent/progress?week=${week}`
   );
   console.log("API response: (progress)", res.data);
   return res.data;

--- a/src/apis/seriesHistory.ts
+++ b/src/apis/seriesHistory.ts
@@ -1,21 +1,16 @@
 import { API } from "./config";
 
 export interface Part {
-  partId: number;
-  isLearned: boolean;
-  part_title: string;
-  part_sub_title: string;
+  msaId: number;
+  title: string;
+  subtitle: string;
 }
 
 export interface Series {
-  seriesId: number;
+  msId: number;
   keyword: string;
   title: string;
   sub_title: string;
-  status: "done" | "ongoing";
-  totalCount: number;
-  learnedCount: number;
-  imgUrl: string;
   parts: Part[];
 }
 

--- a/src/apis/wordHistory.ts
+++ b/src/apis/wordHistory.ts
@@ -23,3 +23,13 @@ export async function getWordHistory(
   console.log("API response:", res.data);
   return res.data;
 }
+
+export async function getParentWordHistory(
+  week: "이번주" | "저번주"
+): Promise<WordHistoryResponse> {
+  const res = await API.get<WordHistoryResponse>(
+    `/users/parent/history/word?week=${week}`
+  );
+  console.log("API response:", res.data);
+  return res.data;
+}

--- a/src/apis/wordHistory.ts
+++ b/src/apis/wordHistory.ts
@@ -2,7 +2,7 @@ import { Category } from "@/types/category";
 import { API } from "./config";
 
 export interface Word {
-  wordId: number;
+  mwiId: number;
   category: Category;
   word: string;
   meaning: string;

--- a/src/app/user/components/Dropdown.tsx
+++ b/src/app/user/components/Dropdown.tsx
@@ -15,19 +15,20 @@ interface DropdownProps {
     | "keyword"
     | "result"
     | "status";
-  value?: string | number | null;
+  value?: string | null;
   onChange?: (value: string | number) => void;
 }
 
 export default function Dropdown({ type, value, onChange }: DropdownProps) {
-  const studentId = 1;
-  const [week, setWeek] = useState<"이번주" | "저번주">("이번주");
-
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
   const [seriesList, setSeriesList] = useState<Series[]>([]);
   const keywords = Array.from(new Set(seriesList.map((s) => s.keyword))); // keyword 중복 제거
+
+  const [selectedValue, setSelectedValue] = useState<string | null>(
+    value ?? null
+  );
 
   // useEffect(() => {
   //   getSeriesHistory(studentId, week)
@@ -51,16 +52,17 @@ export default function Dropdown({ type, value, onChange }: DropdownProps) {
     };
   }, []);
 
-  const handleSelect = (selectedValue: string | number) => {
+  const handleSelect = (val: string | number) => {
+    setSelectedValue(val as string);
     setIsOpen(false);
-    onChange?.(selectedValue);
+    onChange?.(val);
   };
 
   const defaultPlaceholder = {
     year: new Date().getFullYear() + "년",
     month: new Date().getMonth() + 1 + "월",
     week: "이번주",
-    category: "카테고리",
+    category: "전체",
     keyword: "키워드",
     result: "전체",
     status: "전체",
@@ -83,7 +85,7 @@ export default function Dropdown({ type, value, onChange }: DropdownProps) {
           color: COLORS.sub.gray3,
         }}
       >
-        {value || defaultPlaceholder}
+        {selectedValue || defaultPlaceholder}
       </span>
       <Image
         src="/icons/Arrow_Down.png"

--- a/src/app/user/components/HistoryBtn.tsx
+++ b/src/app/user/components/HistoryBtn.tsx
@@ -8,9 +8,10 @@ import { useRouter } from "next/navigation";
 interface HistoryBtnProps {
   type: "word" | "news" | "series";
   week: "이번주" | "저번주";
+  role: "student" | "parent";
 }
 
-export default function HistoryBtn({ type, week }: HistoryBtnProps) {
+export default function HistoryBtn({ type, week, role }: HistoryBtnProps) {
   const [isHover, setIsHover] = useState(false);
   const [isActive, setIsActive] = useState(false);
 
@@ -22,7 +23,7 @@ export default function HistoryBtn({ type, week }: HistoryBtnProps) {
   const router = useRouter();
 
   const handleClick = () => {
-    router.push(`/user/historyPage?type=${type}&week=${week}`);
+    router.push(`/user/historyPage?type=${type}&week=${week}&role=${role}`);
   };
 
   return (

--- a/src/app/user/components/Options.tsx
+++ b/src/app/user/components/Options.tsx
@@ -27,11 +27,14 @@ export default function Options({ type, onSelect, keywords }: OptionsProps) {
       case "category":
         return [
           "전체",
-          "정책/규제",
-          "거시경제",
-          "특집/이슈",
-          "글로벌경제",
           "금융/시장",
+          "거시경제",
+          "생활경제",
+          "글로벌경제",
+          "산업/기업",
+          "특집/이슈",
+          "테크/신사업",
+          "정책/규제",
         ];
       case "keyword":
         return ["전체", ...(keywords ?? [])];

--- a/src/app/user/components/ProgressBtn.tsx
+++ b/src/app/user/components/ProgressBtn.tsx
@@ -4,11 +4,15 @@ import { useRouter } from "next/navigation";
 import { FONT_SIZE, FONT_WEIGHT, COLORS, SHADOW } from "@/styles/theme/tokens";
 import Image from "next/image";
 
-export default function ProgressBtn() {
+interface ProgressBtnProps {
+  role: "student" | "parent";
+}
+
+export default function ProgressBtn({ role }: ProgressBtnProps) {
   const router = useRouter();
 
   const handleClick = () => {
-    router.push("/user/studentProgress");
+    router.push(`/user/studentProgress?role=${role}`);
   };
 
   return (

--- a/src/app/user/historyPage/components/HomeBtn.tsx
+++ b/src/app/user/historyPage/components/HomeBtn.tsx
@@ -3,7 +3,12 @@
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 
-export default function HomeBtn() {
+interface HomeBtnProps {
+  role: "student" | "parent";
+  studentId?: string | null; // 부모일 경우만 필요
+}
+
+export default function HomeBtn({ role, studentId }: HomeBtnProps) {
   const router = useRouter();
 
   return (
@@ -12,7 +17,11 @@ export default function HomeBtn() {
       alt="home"
       width={40}
       height={40}
-      onClick={() => router.push("/user/student")}
+      onClick={() =>
+        router.push(
+          role === "student" ? `/user/student` : `/user/parent/${studentId}`
+        )
+      }
       className="cursor-pointer"
     />
   );

--- a/src/app/user/historyPage/components/NewsHistory.tsx
+++ b/src/app/user/historyPage/components/NewsHistory.tsx
@@ -22,7 +22,10 @@ export default function NewsHistory({
 
   useEffect(() => {
     getNewsHistory(week)
-      .then((data) => setNews(data.newsList))
+      .then((data) => {
+        console.log("뉴스 히스토리 데이터:", data.newsList);
+        setNews(data.newsList);
+      })
       .catch((err) => console.error("뉴스 히스토리 API 실패:", err));
   }, [week]);
 
@@ -42,7 +45,7 @@ export default function NewsHistory({
     <div className="flex flex-wrap gap-x-10 gap-y-15 p-2">
       {filteredNews.map((news) => (
         <NewsCard
-          key={news.newsId}
+          key={news.mnId}
           category={news.category}
           title={news.title}
           imgUrl={news.imgUrl}

--- a/src/app/user/historyPage/components/NewsHistory.tsx
+++ b/src/app/user/historyPage/components/NewsHistory.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
-import { News, getNewsHistory } from "@/apis/newsHistory";
+import { News, getNewsHistory, getParentNewsHistory } from "@/apis/newsHistory";
 import NewsCard from "./NewsCard";
 import { Category } from "@/types/category";
 
@@ -16,18 +16,25 @@ export default function NewsHistory({
   resultFilter,
 }: NewsHistoryProps) {
   const searchParams = useSearchParams();
+  const role = searchParams.get("role") as "student" | "parent";
   const week = searchParams.get("week") === "이번주" ? "이번주" : "저번주";
 
   const [news, setNews] = useState<News[]>([]);
 
   useEffect(() => {
-    getNewsHistory(week)
-      .then((data) => {
-        console.log("뉴스 히스토리 데이터:", data.newsList);
+    const fetchData = async () => {
+      try {
+        const data =
+          role === "parent"
+            ? await getParentNewsHistory(week)
+            : await getNewsHistory(week);
         setNews(data.newsList);
-      })
-      .catch((err) => console.error("뉴스 히스토리 API 실패:", err));
-  }, [week]);
+      } catch (err) {
+        console.error("뉴스 히스토리 API 실패:", err);
+      }
+    };
+    fetchData();
+  }, [week, role]);
 
   const filteredNews = news.filter((news) => {
     // 카테고리 필터

--- a/src/app/user/historyPage/components/SeriesCard.tsx
+++ b/src/app/user/historyPage/components/SeriesCard.tsx
@@ -4,20 +4,20 @@ import Image from "next/image";
 
 interface SeriesCardProps {
   keyword: string;
-  status: "ongoing" | "done";
-  totalCount: number;
-  learnedCount: number;
-  imgUrl: string;
+  // status: "ongoing" | "done";
+  // totalCount: number;
+  // learnedCount: number;
+  // imgUrl: string;
   title: string;
   onClick?: () => void;
 }
 
 export default function SeriesCard({
   keyword,
-  status,
-  totalCount,
-  learnedCount,
-  imgUrl,
+  // status,
+  // totalCount,
+  // learnedCount,
+  // imgUrl,
   title,
   onClick,
 }: SeriesCardProps) {
@@ -33,13 +33,13 @@ export default function SeriesCard({
       onClick={onClick}
     >
       <div className="absolute flex -top-3.5 right-7">
-        {status && (
+        {/* {status && (
           <HistoryStatusBtn
             status={status}
             totalCount={totalCount}
             learnedCount={learnedCount}
           />
-        )}
+        )} */}
       </div>
       <div
         style={{
@@ -50,20 +50,14 @@ export default function SeriesCard({
         {keyword}
       </div>
       <div className="flex items-center justify-center w-44 h-44 rounded-[10px] border border-gray-300 mt-4">
-        {imgUrl ? (
+        {/* {imgUrl ? (
           <div className="relative w-44 h-44 rounded-[10px] overflow-hidden">
             <Image src={imgUrl} alt={title} fill className="object-cover" />
           </div>
-        ) : (
-          <div className="relative w-20 h-20 mx-auto my-auto">
-            <Image
-              src={defaultImg}
-              alt={title}
-              fill
-              className="object-contain"
-            />
-          </div>
-        )}
+        ) : ( */}
+        <div className="relative w-20 h-20 mx-auto my-auto">
+          <Image src={defaultImg} alt={title} fill className="object-contain" />
+        </div>
       </div>
       <div
         className="relative group pt-4"

--- a/src/app/user/historyPage/components/SeriesHistory.tsx
+++ b/src/app/user/historyPage/components/SeriesHistory.tsx
@@ -10,13 +10,9 @@ import { Series, getSeriesHistory } from "@/apis/seriesHistory";
 
 interface SeriesHistoryProps {
   keywordFilter: string | "all";
-  statusFilter: "all" | "done" | "ongoing";
 }
 
-export default function SeriesHistory({
-  keywordFilter,
-  statusFilter,
-}: SeriesHistoryProps) {
+export default function SeriesHistory({ keywordFilter }: SeriesHistoryProps) {
   const searchParams = useSearchParams();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -37,9 +33,6 @@ export default function SeriesHistory({
     // 키워드 필터
     if (keywordFilter !== "all" && series.keyword !== keywordFilter)
       return false;
-
-    // 학습 현황 필터
-    if (statusFilter !== "all" && series.status !== statusFilter) return false;
     return true;
   });
 
@@ -47,12 +40,12 @@ export default function SeriesHistory({
     <div className="grid grid-cols-3 gap-y-15">
       {filteredSeries.map((series) => (
         <SeriesCard
-          key={series.seriesId}
+          key={series.msId}
           keyword={series.keyword}
-          status={series.status}
-          totalCount={series.totalCount}
-          learnedCount={series.learnedCount}
-          imgUrl={series.imgUrl}
+          // status={series.status}
+          // totalCount={series.totalCount}
+          // learnedCount={series.learnedCount}
+          // imgUrl={series.imgUrl}
           title={series.title}
           onClick={() => {
             setSelectedSeries(series);
@@ -89,52 +82,51 @@ export default function SeriesHistory({
             </div>
             {selectedSeries?.parts.map((part) => (
               <div
-                key={part.partId}
+                key={part.msaId}
                 className="cursor-pointer"
                 onClick={() =>
                   router.push(
-                    `/MonSeries/${selectedSeries?.seriesId}/part/${part.partId}`
+                    `/MonSeries/${selectedSeries?.msId}/part/${part.msaId}`
                   )
                 }
               >
                 <div className="flex justify-start items-center gap-[10px] mt-4">
-                  {part.isLearned === true ? (
-                    <Image
-                      src="/icons/Pin_LearnedPart.svg"
-                      alt="Pin"
-                      width={30}
-                      height={30}
-                    />
+                  {/* {part.isLearned === true ? ( */}
+                  <Image
+                    src="/icons/Pin_LearnedPart.svg"
+                    alt="Pin"
+                    width={30}
+                    height={30}
+                  />
                   ) : (
-                    <Image
-                      src="/icons/Pin_UpcomingPart.svg"
-                      alt="Pin"
-                      width={30}
-                      height={30}
-                    />
-                  )}
+                  <Image
+                    src="/icons/Pin_UpcomingPart.svg"
+                    alt="Pin"
+                    width={30}
+                    height={30}
+                  />
                   <div className="flex flex-col">
                     <div
                       style={{
-                        color: part.isLearned
-                          ? COLORS.sub.gray4
-                          : COLORS.sub.black,
+                        // color: part.isLearned
+                        //   ? COLORS.sub.gray4
+                        //   : COLORS.sub.black,
                         fontSize: FONT_SIZE.body1,
                         fontWeight: FONT_WEIGHT.body1,
                       }}
                     >
-                      {part.part_title}
+                      {part.title}
                     </div>
                     <div
                       style={{
-                        color: part.isLearned
-                          ? COLORS.sub.gray3
-                          : COLORS.sub.black,
+                        // color: part.isLearned
+                        //   ? COLORS.sub.gray3
+                        //   : COLORS.sub.black,
                         fontSize: FONT_SIZE.caption2,
                         fontWeight: FONT_WEIGHT.caption2,
                       }}
                     >
-                      {part.part_sub_title}
+                      {part.subtitle}
                     </div>
                   </div>
                 </div>

--- a/src/app/user/historyPage/components/WordHistory.tsx
+++ b/src/app/user/historyPage/components/WordHistory.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
-import { Word, getWordHistory } from "@/apis/wordHistory";
+import { Word, getWordHistory, getParentWordHistory } from "@/apis/wordHistory";
 import { COLORS, SHADOW } from "@/styles/theme/tokens";
 import WordItem from "./WordItem";
 import { Category } from "@/types/category";
@@ -17,15 +17,25 @@ export default function WordHistory({
   resultFilter,
 }: WordHistoryProps) {
   const searchParams = useSearchParams();
+  const role = searchParams.get("role") as "student" | "parent";
   const week = searchParams.get("week") === "저번주" ? "저번주" : "이번주";
 
   const [words, setWords] = useState<Word[]>([]);
 
   useEffect(() => {
-    getWordHistory(week)
-      .then((data) => setWords(data.wordList))
-      .catch((err) => console.error("단어 히스토리 API 실패:", err));
-  }, [week]);
+    const fetchData = async () => {
+      try {
+        const data =
+          role === "parent"
+            ? await getParentWordHistory(week)
+            : await getWordHistory(week);
+        setWords(data.wordList);
+      } catch (err) {
+        console.error("뉴스 히스토리 API 실패:", err);
+      }
+    };
+    fetchData();
+  }, [week, role]);
 
   const filteredWords = words.filter((word) => {
     // 카테고리 필터

--- a/src/app/user/historyPage/components/WordHistory.tsx
+++ b/src/app/user/historyPage/components/WordHistory.tsx
@@ -49,7 +49,7 @@ export default function WordHistory({
     >
       {filteredWords.map((word) => (
         <WordItem
-          key={word.wordId}
+          key={word.mwiId}
           category={word.category}
           word={word.word}
           explain={word.meaning}

--- a/src/app/user/historyPage/page.tsx
+++ b/src/app/user/historyPage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import HomeBtn from "./components/HomeBtn";
 import Dropdown from "../components/Dropdown";
@@ -10,9 +10,12 @@ import SeriesHistory from "./components/SeriesHistory";
 import { COLORS, FONT_SIZE, FONT_WEIGHT } from "@/styles/theme/tokens";
 import { Category } from "@/types/category";
 import { Category_Label } from "../../../../constants/categoryLabel";
+import { getParentInfo } from "@/apis/parentInfo";
 
 export default function HistoryPage() {
   const searchParams = useSearchParams();
+  const role = searchParams.get("role") === "parent" ? "parent" : "student";
+  const [studentId, setStudentId] = useState<string | null>(null);
   const type = searchParams.get("type") || "series";
 
   const [keywordFilter, setKeywordFilter] = useState<"all" | string>("all");
@@ -23,6 +26,23 @@ export default function HistoryPage() {
   const [resultFilter, setResultFilter] = useState<
     "all" | "correct" | "incorrect"
   >("all");
+
+  // 부모일 때만 studentId 가져오기
+  useEffect(() => {
+    if (role === "parent") {
+      const fetchStudentId = async () => {
+        try {
+          const parentInfo = await getParentInfo();
+          if (parentInfo.studentIds && parentInfo.studentIds.length > 0) {
+            setStudentId(parentInfo.studentIds[0]);
+          }
+        } catch (err) {
+          console.error("부모 정보 불러오기 실패:", err);
+        }
+      };
+      fetchStudentId();
+    }
+  }, [role]);
 
   const label =
     {
@@ -63,7 +83,7 @@ export default function HistoryPage() {
 
   return (
     <div className="relative w-full px-20 py-5">
-      <HomeBtn />
+      <HomeBtn role={role} studentId={role === "parent" ? studentId : ""} />
       <div className="flex flex-col items-stretch w-[900px] pt-10 pl-16">
         <div
           className="flex"

--- a/src/app/user/parent/[studentId]/page.tsx
+++ b/src/app/user/parent/[studentId]/page.tsx
@@ -55,6 +55,9 @@ export default function ParentPage() {
 
   // 퀴즈 성적
   const [quizResults, setQuizResults] = useState<Result[]>([]);
+  const uniqueQuizResults = quizResults.filter(
+    (quiz, index, self) => index === self.findIndex((q) => q.day === quiz.day)
+  );
 
   const [selectedTab, setSelectedTab] = useState<"word" | "news">("word");
   const handleTabChange = (value: { selectedTab: "word" | "news" }) => {
@@ -351,7 +354,7 @@ export default function ParentPage() {
           이번 주 퀴즈
         </div>
         <div className="flex flex-col pt-5 gap-2.5">
-          {quizResults.map((quiz) => (
+          {uniqueQuizResults.map((quiz) => (
             <QuizBtn key={quiz.day} day={quiz.day} score={quiz.score} />
           ))}
         </div>

--- a/src/app/user/parent/[studentId]/page.tsx
+++ b/src/app/user/parent/[studentId]/page.tsx
@@ -189,7 +189,7 @@ export default function ParentPage() {
                   fontWeight: FONT_WEIGHT.body2,
                 }}
               >
-                하루 학습(단어·뉴스·퀴즈·시리즈)을 모두 완료한 일수
+                하루 학습(단어·뉴스·퀴즈)을 모두 완료한 일수
               </div>
             </div>
           </div>

--- a/src/app/user/parent/[studentId]/page.tsx
+++ b/src/app/user/parent/[studentId]/page.tsx
@@ -362,9 +362,9 @@ export default function ParentPage() {
 
       {/*히스토리 버튼*/}
       <div className="absolute top-150 left-145 flex flex-col gap-5">
-        <HistoryBtn type="word" week={week} />
-        <HistoryBtn type="news" week={week} />
-        <HistoryBtn type="series" week={week} />
+        <HistoryBtn type="word" week={week} role="parent" />
+        <HistoryBtn type="news" week={week} role="parent" />
+        <HistoryBtn type="series" week={week} role="parent" />
       </div>
 
       {/*경제 TalkTalk*/}

--- a/src/app/user/parent/[studentId]/page.tsx
+++ b/src/app/user/parent/[studentId]/page.tsx
@@ -23,7 +23,7 @@ import Slider from "../../components/Slider";
 import HistoryBtn from "../../components/HistoryBtn";
 import QuizBtn from "../components/QuizBtn";
 import { getStudentInfoById, StdInfoResponse } from "@/apis/studentInfo";
-import { getStudentProgress, ProgressResponse } from "@/apis/progress";
+import { getParentProgress, ProgressResponse } from "@/apis/progress";
 import AssignLoading from "@/components/shared/AssignLoading";
 
 export default function ParentPage() {
@@ -90,7 +90,7 @@ export default function ParentPage() {
       setWeaknessData(weakness);
 
       // 총 학습일 조회
-      const progressData = await getStudentProgress(id, week);
+      const progressData = await getParentProgress(week);
       console.log("progressData:", progressData);
       setProgress(progressData);
 
@@ -237,7 +237,7 @@ export default function ParentPage() {
           >
             이번 주 출석 현황
           </div>
-          <ProgressBtn />
+          <ProgressBtn role="parent" />
         </div>
         <div className="pt-4">
           <AttendBtn

--- a/src/app/user/parent/components/AddStudentModal.tsx
+++ b/src/app/user/parent/components/AddStudentModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { COLORS, FONT_SIZE, FONT_WEIGHT, SHADOW } from "@/styles/theme/tokens";
 import SearchInput from "./SerchInput";
 import { getStudentByEmail, StdInfoResponse } from "@/apis/studentInfo";
+import { addStudent } from "@/apis/parentInfo";
 
 interface AddStudentProps {
   closeRequest: () => void;
@@ -11,7 +12,7 @@ interface AddStudentProps {
 }
 
 interface StudentProps {
-  id: number;
+  id: string;
   name: string;
   school: string;
   grade: string;
@@ -28,7 +29,7 @@ export default function AddStudentModal({
       console.log("검색 결과:", data);
       // 타입 맞춰서 변환
       setStudent({
-        id: data.std_id,
+        id: data.std_id.toString(),
         name: data.std_name,
         school: data.std_schoolType,
         grade: `${data.std_grade}학년`,
@@ -40,12 +41,22 @@ export default function AddStudentModal({
     }
   };
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     if (!student) {
       alert("자녀 정보를 먼저 검색해주세요.");
       return;
     }
-    onAddStudent(student);
+    try {
+      // 부모 DB에 studentId 추가
+      const added = await addStudent(student.id);
+      console.log("추가된 학생:", added.student);
+
+      onAddStudent(student);
+      closeRequest();
+    } catch (err) {
+      console.error(err);
+      alert("자녀 추가에 실패했습니다.");
+    }
   };
 
   const handleCancel = () => {

--- a/src/app/user/parent/components/QuizBtn.tsx
+++ b/src/app/user/parent/components/QuizBtn.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { COLORS, FONT_SIZE, FONT_WEIGHT, SHADOW } from "@/styles/theme/tokens";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 interface QuizBtnProps {
   day: string;
@@ -10,6 +13,11 @@ export default function QuizBtn({ day, score }: QuizBtnProps) {
   const date = new Date(day);
   const month = date.getMonth() + 1;
   const d = date.getDate();
+
+  // const router = useRouter();
+  // const handleClick = () => {
+  //   router.push(`/MonQuiz?day=${day}`);
+  // };
 
   return (
     <div className="flex whitespace-nowrap">
@@ -23,7 +31,7 @@ export default function QuizBtn({ day, score }: QuizBtnProps) {
       >
         {`${month}월 ${d}일`}
         <div
-          className="flex absolute justify-center items-center w-26 h-6 left-48 rounded-[30px]"
+          className="flex absolute justify-center items-center w-26 h-6 left-55 rounded-[30px]"
           style={{
             backgroundColor: COLORS.primary.mint,
             fontSize: FONT_SIZE.body2,
@@ -33,14 +41,17 @@ export default function QuizBtn({ day, score }: QuizBtnProps) {
         >
           점수 : {score}점
         </div>
-        <div className="pl-6 absolute left-73 cursor-pointer">
+        {/* <div
+          className="pl-6 absolute left-73 cursor-pointer"
+          onClick={handleClick}
+        >
           <Image
             src="/icons/Arrow_right.svg"
             alt="arrow"
             width={24}
             height={24}
           />
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/src/app/user/parent/components/QuizBtn.tsx
+++ b/src/app/user/parent/components/QuizBtn.tsx
@@ -1,4 +1,3 @@
-import { QuizItemProps } from "@/app/(main)/MonQuiz/components/QuizItem";
 import { COLORS, FONT_SIZE, FONT_WEIGHT, SHADOW } from "@/styles/theme/tokens";
 import Image from "next/image";
 

--- a/src/app/user/parent/mypage/page.tsx
+++ b/src/app/user/parent/mypage/page.tsx
@@ -11,7 +11,7 @@ import EditModal from "../components/EditModal";
 import { getParentInfo } from "@/apis/parentInfo";
 
 interface StudentProps {
-  id: number;
+  id: string;
   name: string;
   school: string;
   grade: string;
@@ -32,7 +32,7 @@ export default function ParentMyPage() {
   }, []);
 
   // 자녀 삭제
-  const handleDeleteStudent = (id?: number) => {
+  const handleDeleteStudent = (id?: string) => {
     setStudents(students.filter((s) => s.id !== id));
   };
 
@@ -109,7 +109,7 @@ export default function ParentMyPage() {
           <div className="flex flex-col px-10 gap-5 pt-6">
             <InputBox
               type="text"
-              value={user?.prt_name || "?"}
+              value={user?.prt_name}
               label="이름"
               readOnly
             />
@@ -138,10 +138,9 @@ export default function ParentMyPage() {
           </div>
           {/*자녀 리스트*/}
           <div className="flex flex-wrap p-6 gap-3">
-            {students.map((s) => (
-              //<div key={s.id}>
+            {students.map((s, idx) => (
               <StudentCard
-                key={s.id}
+                key={`${s.id}-${idx}`}
                 name={s.name || ""}
                 school={s.school || ""}
                 grade={s.grade || ""}
@@ -149,7 +148,6 @@ export default function ParentMyPage() {
                 onDelete={() => handleDeleteStudent(s.id)}
                 onClick={() => router.push(`/user/parent/${s.id}`)}
               />
-              //</div>
             ))}
             {/*자녀 추가 버튼*/}
             <div

--- a/src/app/user/student/page.tsx
+++ b/src/app/user/student/page.tsx
@@ -490,9 +490,9 @@ export default function StudentMyPage() {
 
             {/*히스토리 버튼*/}
             <div className="flex absolute flex-col gap-5 top-195 left-130">
-              <HistoryBtn type="word" week={week} />
-              <HistoryBtn type="news" week={week} />
-              <HistoryBtn type="series" week={week} />
+              <HistoryBtn type="word" week={week} role="student" />
+              <HistoryBtn type="news" week={week} role="student" />
+              <HistoryBtn type="series" week={week} role="student" />
             </div>
           </div>
         </div>

--- a/src/app/user/student/page.tsx
+++ b/src/app/user/student/page.tsx
@@ -394,7 +394,7 @@ export default function StudentMyPage() {
                   >
                     🎯 출석 및 학습 진행률
                   </div>
-                  <ProgressBtn />
+                  <ProgressBtn role="student" />
                 </div>
                 <AttendBtn
                   days_gap={80}

--- a/src/app/user/student/page.tsx
+++ b/src/app/user/student/page.tsx
@@ -193,8 +193,7 @@ export default function StudentMyPage() {
                     fontSize: FONT_SIZE.body1,
                   }}
                 >
-                  하루에 단어·뉴스·퀴즈·시리즈를 모두 끝내면 스트라이크 수가
-                  쌓여요.
+                  하루에 단어·뉴스·퀴즈를 모두 끝내면 스트라이크 수가 쌓여요.
                   <br />이 스트라이크 수가 일정 기준을 넘을 때마다 레벨이
                   올라갑니다. <br />
                   <br />

--- a/src/app/user/studentProgress/components/ProgressItem.tsx
+++ b/src/app/user/studentProgress/components/ProgressItem.tsx
@@ -26,7 +26,7 @@ export default function ProgressItem({ days }: ProgressItemProps) {
               <StatusBtn
                 key={label}
                 label={label}
-                status={status as "done" | "ongoing" | "pending"}
+                status={status as "done" | "pending"}
               />
             ))}
           </div>

--- a/src/app/user/studentProgress/components/StatusBtn.tsx
+++ b/src/app/user/studentProgress/components/StatusBtn.tsx
@@ -4,13 +4,12 @@ import { useRouter } from "next/navigation";
 
 interface StatusBtnProps {
   label: string;
-  status: "done" | "ongoing" | "pending";
+  status: "done" | "pending";
 }
 
 const labelMap: Record<StatusBtnProps["label"], string> = {
   word: "단어",
   news: "뉴스",
-  series: "시리즈",
   quiz: "퀴즈",
 };
 
@@ -23,11 +22,11 @@ export default function StatusBtn({ label, status }: StatusBtnProps) {
           backgroundColor: COLORS.primary.mint,
           color: COLORS.series.deepGreen,
         };
-      case "ongoing":
-        return {
-          backgroundColor: COLORS.series.yellow2,
-          color: COLORS.series.yellow3,
-        };
+      // case "ongoing":
+      //   return {
+      //     backgroundColor: COLORS.series.yellow2,
+      //     color: COLORS.series.yellow3,
+      //   };
       case "pending":
         return {
           backgroundColor: COLORS.series.error,

--- a/src/app/user/studentProgress/page.tsx
+++ b/src/app/user/studentProgress/page.tsx
@@ -12,31 +12,45 @@ import {
   ProgressResponse,
   getParentProgress,
 } from "@/apis/progress";
+import { getParentInfo } from "@/apis/parentInfo";
 
 export default function StudentMyPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const role = searchParams.get("role") === "parent" ? "parent" : "student";
   const [progress, setProgress] = useState<ProgressResponse | null>(null);
+  const [studentId, setStudentId] = useState<string | null>(null);
 
   // 기본을 이번주로 수정
   const week = searchParams.get("week") === "저번주" ? "저번주" : "이번주";
 
   useEffect(() => {
-    const fetchProgress = async () => {
+    const fetchData = async () => {
       try {
-        let data;
-        if (role === "student") {
-          data = await getProgress(week);
+        let id: string | null = null;
+
+        if (role === "parent") {
+          const parentInfo = await getParentInfo();
+          console.log("parentInfo:", parentInfo);
+          if (!parentInfo.studentIds || parentInfo.studentIds.length === 0) {
+            console.error("자녀 정보가 없습니다.");
+            return;
+          }
+          id = parentInfo.studentIds[0]; // 학생 한 명만 있다고 가정
+          setStudentId(id);
+
+          const data = await getParentProgress(week);
+          setProgress(data);
         } else {
-          data = await getParentProgress(week);
+          const data = await getProgress(week);
+          setProgress(data);
         }
-        setProgress(data);
       } catch (err) {
         console.error("진도 API 실패:", err);
       }
     };
-    fetchProgress();
+
+    fetchData();
   }, [week, role]);
 
   if (!progress) return <div>Loading...</div>;
@@ -49,7 +63,11 @@ export default function StudentMyPage() {
           alt="home"
           width={40}
           height={40}
-          onClick={() => router.push("/user/student")}
+          onClick={() =>
+            router.push(
+              role === "student" ? `/user/student` : `/user/parent/${studentId}`
+            )
+          }
           className="cursor-pointer"
         />
         <div className="flex flex-col items-stretch justify-between w-[900px] pt-10 px-5 pl-16">

--- a/src/app/user/studentProgress/page.tsx
+++ b/src/app/user/studentProgress/page.tsx
@@ -55,7 +55,7 @@ export default function StudentMyPage() {
           <div className="pt-10">
             <ProgressSlider
               weekCompletionRate={progress.weekCompletionRate}
-              strikeDay={progress.strikeDay}
+              strikeDay={progress.strikeDay || 0}
             />
           </div>
           {/*진도 현황*/}

--- a/src/app/user/studentProgress/page.tsx
+++ b/src/app/user/studentProgress/page.tsx
@@ -7,21 +7,37 @@ import { FONT_SIZE, FONT_WEIGHT, COLORS } from "@/styles/theme/tokens";
 import Image from "next/image";
 import ProgressSlider from "./components/ProgressSlider";
 import ProgressItem from "./components/ProgressItem";
-import { getProgress, ProgressResponse } from "@/apis/progress";
+import {
+  getProgress,
+  ProgressResponse,
+  getParentProgress,
+} from "@/apis/progress";
 
 export default function StudentMyPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const role = searchParams.get("role") === "parent" ? "parent" : "student";
   const [progress, setProgress] = useState<ProgressResponse | null>(null);
 
-  const searchParams = useSearchParams();
   // 기본을 이번주로 수정
   const week = searchParams.get("week") === "저번주" ? "저번주" : "이번주";
 
   useEffect(() => {
-    getProgress(week)
-      .then((data) => setProgress(data))
-      .catch((err) => console.error("진도 API 실패:", err));
-  }, [week]);
+    const fetchProgress = async () => {
+      try {
+        let data;
+        if (role === "student") {
+          data = await getProgress(week);
+        } else {
+          data = await getParentProgress(week);
+        }
+        setProgress(data);
+      } catch (err) {
+        console.error("진도 API 실패:", err);
+      }
+    };
+    fetchProgress();
+  }, [week, role]);
 
   if (!progress) return <div>Loading...</div>;
 

--- a/src/app/user/studentProgress/page.tsx
+++ b/src/app/user/studentProgress/page.tsx
@@ -113,7 +113,7 @@ export default function StudentMyPage() {
               >
                 <div className="ml-5">완료</div>
               </div>
-              <div
+              {/* <div
                 className="flex items-center w-3 h-3 rounded-full"
                 style={{
                   backgroundColor: COLORS.series.yellow2,
@@ -121,7 +121,7 @@ export default function StudentMyPage() {
                 }}
               >
                 <div className="ml-5">진행중</div>
-              </div>
+              </div> */}
               <div
                 className="flex items-center w-3 h-3 rounded-full ml-3"
                 style={{

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,9 +1,9 @@
 export type Category =
-  | "MONEY"
-  | "BIGPICTURE"
-  | "DAILYLIFE"
-  | "GLOBAL"
-  | "INDUSTRIES"
-  | "ISSUES"
-  | "TECH"
-  | "RULES";
+  | "cg00"
+  | "cg01"
+  | "cg02"
+  | "cg03"
+  | "cg04"
+  | "cg05"
+  | "cg06"
+  | "cg07";


### PR DESCRIPTION
## 📌 Related Issue

close #93 

## ✨ Work Description

- 히스토리 페이지에서 category 뜨게 수정
- 학부모 히스토리 페이지와 진도현황 페이지는 studentId를 body에 넣어서 가져옴 (기존엔 url에서 가져와서 보안문제)
- 학부모/학생 홈버튼 조건 분리 
- series progress에서 제거 

## 📢 Notices

progress DB가 비어있을 때 오류가 생김 .. 
